### PR TITLE
[UncoverFoundationedOceans] fix for game version 0.10.32.25682

### DIFF
--- a/UncoverFoundationedOceans/UncoverFoundationedOceans.cs
+++ b/UncoverFoundationedOceans/UncoverFoundationedOceans.cs
@@ -201,7 +201,7 @@ namespace DysonSphereProgram.Modding.UncoverFoundationedOceans
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(PlanetFactory), nameof(PlanetFactory.ComputeFlattenTerrainReform))]
-    static void PostCompute(ref PlanetFactory __instance, ref int __result)
+    static void PostCompute(ref PlanetFactory __instance, ref int costSandCount, ref int getSandCount)
     {
       __instance.tmp_levelChanges.Clear();
 
@@ -241,9 +241,18 @@ namespace DysonSphereProgram.Modding.UncoverFoundationedOceans
         }
       }
 
-      //Plugin.Log.LogDebug($"Total: {totalCount}; Effective: {effectiveCount}");
+      if (soilRequired < 0)
+      {
+        costSandCount = 0;
+        getSandCount = -soilRequired;
+      }
+      else
+      {
+        costSandCount = soilRequired;
+        getSandCount = 0;
+      }
 
-      __result = soilRequired;
+      //Plugin.Log.LogDebug($"Total: {totalCount}; Effective: {effectiveCount}");
     }
 
     [HarmonyTranspiler]


### PR DESCRIPTION
I had fix this problem for https://github.com/Velociraptor115-DSPModding/DSPMods/issues/28.

The game after recent update have one diffrent to make this mod not working:

PlanetFactory.ComputeFlattenTerrainReform change it's signature to `public void ComputeFlattenTerrainReform(Vector3[] points, Vector3 center, float radius, int pointsCount, ref int costSandCount, ref int getSandCount, float fade0 = 3, float fade1 = 1);`

I have adapted the above changes. The sand cost tested and it works right.